### PR TITLE
Package proto files

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ NumProto serializes a numpy array into an `NDArray` message as specified in
 ```proto
 syntax = "proto3";
 
-package numproto.ndarray;
+package numproto;
 
 message NDArray {
     bytes ndarray = 1;
@@ -56,7 +56,7 @@ This allows us to simply pass the `site-packages` path as an import path to
 > running `pip show numproto`.
 
 For example let's say we want to create a new `proto` file and import `NDArray`
-to use withing one of our defined messages:
+to use within one of our defined messages:
 
 ```proto
 syntax = "proto3";
@@ -64,7 +64,7 @@ syntax = "proto3";
 import "numproto/protobuf/ndarray.proto";
 
 message MyMessage {
-    numproto.ndarray.NDArray my_array = 1;
+    numproto.NDArray my_array = 1;
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -14,10 +14,12 @@ $ pip install numproto
 ## Usage
 
 NumProto serializes a numpy array into an `NDArray` message as specified in
-[ndarray.proto](https://github.com/xainag/numproto/blob/master/xain/protobuf/ndarray.proto):
+[ndarray.proto](https://github.com/xainag/numproto/blob/master/numproto/protobuf/ndarray.proto):
 
 ```proto
 syntax = "proto3";
+
+package numproto.ndarray;
 
 message NDArray {
     bytes ndarray = 1;
@@ -39,6 +41,38 @@ deserialized_nda = proto_to_ndarray(serialized_nda)
 
 assert np.array_equal(nda, deserialized_nda)
 ```
+
+### Re-using the proto files in another project
+
+Re-distributing `*.proto` files is notoriously difficult. In order to make this
+easier the
+[ndarray.proto](https://github.com/xainag/numproto/blob/master/numproto/protobuf/ndarray.proto)
+file is installed together with the python package.
+
+This allows us to simply pass the `site-packages` path as an import path to
+`protoc`.
+
+> To get the correct path of `site-packages` check the _Location_ key when
+> running `pip show numproto`.
+
+For example let's say we want to create a new `proto` file and import `NDArray`
+to use withing one of our defined messages:
+
+```proto
+syntax = "proto3";
+
+import "numproto/protobuf/ndarray.proto";
+
+message MyMessage {
+    numproto.ndarray.NDArray my_array = 1;
+}
+```
+
+And to compile using `grpcio-tools` simply do:
+```bash
+$ python -m grpc_tools.protoc -I/usr/lib/python3.6/site-packages/ -I./ --python_out=. --grpc_python_out=. my_proto.proto
+```
+(you may need to adjust the location of `site-packages`)
 
 ## Tests
 

--- a/numproto/ndarray_pb2.py
+++ b/numproto/ndarray_pb2.py
@@ -17,10 +17,10 @@ _sym_db = _symbol_database.Default()
 
 DESCRIPTOR = _descriptor.FileDescriptor(
   name='ndarray.proto',
-  package='',
+  package='numproto.ndarray',
   syntax='proto3',
   serialized_options=None,
-  serialized_pb=_b('\n\rndarray.proto\"\x1a\n\x07NDArray\x12\x0f\n\x07ndarray\x18\x01 \x01(\x0c\x62\x06proto3')
+  serialized_pb=_b('\n\rndarray.proto\x12\x10numproto.ndarray\"\x1a\n\x07NDArray\x12\x0f\n\x07ndarray\x18\x01 \x01(\x0c\x62\x06proto3')
 )
 
 
@@ -28,13 +28,13 @@ DESCRIPTOR = _descriptor.FileDescriptor(
 
 _NDARRAY = _descriptor.Descriptor(
   name='NDArray',
-  full_name='NDArray',
+  full_name='numproto.ndarray.NDArray',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='ndarray', full_name='NDArray.ndarray', index=0,
+      name='ndarray', full_name='numproto.ndarray.NDArray.ndarray', index=0,
       number=1, type=12, cpp_type=9, label=1,
       has_default_value=False, default_value=_b(""),
       message_type=None, enum_type=None, containing_type=None,
@@ -52,8 +52,8 @@ _NDARRAY = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=17,
-  serialized_end=43,
+  serialized_start=35,
+  serialized_end=61,
 )
 
 DESCRIPTOR.message_types_by_name['NDArray'] = _NDARRAY
@@ -62,7 +62,7 @@ _sym_db.RegisterFileDescriptor(DESCRIPTOR)
 NDArray = _reflection.GeneratedProtocolMessageType('NDArray', (_message.Message,), {
   'DESCRIPTOR' : _NDARRAY,
   '__module__' : 'ndarray_pb2'
-  # @@protoc_insertion_point(class_scope:NDArray)
+  # @@protoc_insertion_point(class_scope:numproto.ndarray.NDArray)
   })
 _sym_db.RegisterMessage(NDArray)
 

--- a/numproto/ndarray_pb2.py
+++ b/numproto/ndarray_pb2.py
@@ -17,10 +17,10 @@ _sym_db = _symbol_database.Default()
 
 DESCRIPTOR = _descriptor.FileDescriptor(
   name='ndarray.proto',
-  package='numproto.ndarray',
+  package='numproto',
   syntax='proto3',
   serialized_options=None,
-  serialized_pb=_b('\n\rndarray.proto\x12\x10numproto.ndarray\"\x1a\n\x07NDArray\x12\x0f\n\x07ndarray\x18\x01 \x01(\x0c\x62\x06proto3')
+  serialized_pb=_b('\n\rndarray.proto\x12\x08numproto\"\x1a\n\x07NDArray\x12\x0f\n\x07ndarray\x18\x01 \x01(\x0c\x62\x06proto3')
 )
 
 
@@ -28,13 +28,13 @@ DESCRIPTOR = _descriptor.FileDescriptor(
 
 _NDARRAY = _descriptor.Descriptor(
   name='NDArray',
-  full_name='numproto.ndarray.NDArray',
+  full_name='numproto.NDArray',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='ndarray', full_name='numproto.ndarray.NDArray.ndarray', index=0,
+      name='ndarray', full_name='numproto.NDArray.ndarray', index=0,
       number=1, type=12, cpp_type=9, label=1,
       has_default_value=False, default_value=_b(""),
       message_type=None, enum_type=None, containing_type=None,
@@ -52,8 +52,8 @@ _NDARRAY = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=35,
-  serialized_end=61,
+  serialized_start=27,
+  serialized_end=53,
 )
 
 DESCRIPTOR.message_types_by_name['NDArray'] = _NDARRAY
@@ -62,7 +62,7 @@ _sym_db.RegisterFileDescriptor(DESCRIPTOR)
 NDArray = _reflection.GeneratedProtocolMessageType('NDArray', (_message.Message,), {
   'DESCRIPTOR' : _NDARRAY,
   '__module__' : 'ndarray_pb2'
-  # @@protoc_insertion_point(class_scope:numproto.ndarray.NDArray)
+  # @@protoc_insertion_point(class_scope:numproto.NDArray)
   })
 _sym_db.RegisterMessage(NDArray)
 

--- a/numproto/protobuf/ndarray.proto
+++ b/numproto/protobuf/ndarray.proto
@@ -1,5 +1,7 @@
 syntax = "proto3";
 
+package numproto.ndarray;
+
 message NDArray {
     bytes ndarray = 1;
 }

--- a/numproto/protobuf/ndarray.proto
+++ b/numproto/protobuf/ndarray.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package numproto.ndarray;
+package numproto;
 
 message NDArray {
     bytes ndarray = 1;

--- a/setup.py
+++ b/setup.py
@@ -26,10 +26,10 @@ class CustomDevelopCommand(develop):
 
         develop.run(self)
 
-        proto_files = glob.glob('./xain/protobuf/*.proto')
+        proto_files = glob.glob('./numproto/protobuf/*.proto')
         command = [
             'grpc_tools.protoc',
-            '--proto_path=./xain/protobuf/',
+            '--proto_path=./numproto/protobuf/',
             '--python_out=./numproto',
             '--grpc_python_out=./numproto',
         ] + proto_files
@@ -86,4 +86,9 @@ setup(
         "dev": dev_require + tests_require,
     },
     cmdclass={"develop": CustomDevelopCommand},
+    package_data={
+        "numproto": [
+            "protobuf/*",
+        ],
+    },
 )


### PR DESCRIPTION
This merge request updates the installation to also install the `proto` files.
This will make it easier to import the `proto` files from another project

- Moved the proto files to inside the python source
- Updated setup.py to package the proto files
- Updated README with instructions on how to use the proto file
  from another project